### PR TITLE
Send keys variant for selecting book tour date (fix)

### DIFF
--- a/Generic-Test-Cases/generic-keywords.robot
+++ b/Generic-Test-Cases/generic-keywords.robot
@@ -1,5 +1,6 @@
 *** Settings ***
 Library  SeleniumLibrary
+Library    ../resources/global_files/weekday_helper.py
 Variables  variables.py
 
 *** Keywords ***
@@ -18,14 +19,12 @@ The user is not logged in, and is on the homepage
 They attempt to register with valid credentials
     [Tags]    When
     Click Element    ${nav_menu_register}
-    Input Text    ${USERNAME_FIELD}    ${USERNAME}
-    Input Text    ${PASSWORD_FIELD}    ${PASSWORD}
+    Input Text    ${USERNAME_FIELD}    ${valid_username}
+    Input Text    ${PASSWORD_FIELD}    ${valid_password}
     Click Element    ${SUBMIT_REGISTER}
 
 They should be redirected to the login page
     [Tags]    Then
-    # Should this not look for the login form itself instead of a login button?
-    # Especially since login button is part of the nav-menu and thus always visible --TT
     Wait Until Element Is Visible    ${login_section}    10s
 
 ### Login ###
@@ -81,7 +80,7 @@ They should be redirected to the homepage and see the login button
 They add a '${ticket_type}' ticket to the cart
     [Tags]    When    Given
     Click Element    ${nav_menu_ticket}
-    Wait Until Element Is Visible    ${ticket_type_dropdown}    10s
+    Wait Until Element Is Visible    ${ticket_category_dropdown}    10s
 
     # unsure if this works but this will make it all lowercase from my understanding
     # as shown in valid/invalid, you can skip setting variables and just use `.lower()` right away
@@ -89,14 +88,14 @@ They add a '${ticket_type}' ticket to the cart
     ${ticket_type_lower}    Set Variable    ${ticket_type.lower()}
     
     IF  "${ticket_type_lower}" == "regular"
-        Select From List By Index    ${ticket_type_dropdown}    0
+        Select From List By Index    ${ticket_category_dropdown}    0
     ELSE IF  "${ticket_type_lower}" == "vip"
-        Select From List By Index    ${ticket_type_dropdown}    1
+        Select From List By Index    ${ticket_category_dropdown}    1
     ELSE
         Fail    Invalid ticket type: ${ticket_type}
     END
 
-    ${selected}=    Get Selected List Value    ${ticket_type_dropdown}
+    ${selected}=    Get Selected List Value    ${ticket_category_dropdown}
     ${selected_lower}    Set Variable   ${selected.lower()}
     Should Contain    ${selected_lower}    ${ticket_type_lower}
     Click Element    ${add_ticket_to_cart_button}
@@ -113,23 +112,7 @@ They should be able to see the ticket in the cart
     Should Contain    ${listed_items}    Ticket    #Currently hardcoded to test, not sure if its needed as variable.-TT
 
 ### Tour ###
-They add a viable tour with a chosen date to the cart
-    [Tags]    When
-    Click Element    ${nav_menu_safari}
-    Wait Until Element Is Visible    ${safari_section}    10s
-    Click Element    ${safari_date_input_field}
-    #TODO: FIGURE OUT WHY AMERICAN DATE INPUT WORKS DESPITE OUR WEBSITE BEING DD-MM-YYYY. I hate this -TT
-    ## I initially thought it was because we used 'en-us' locale. BUT the issue still persists with 'en-GB'.
-    ## Conclusion: The website is trolling us. Legit decide and dont use all 3 variants man 🙃
-    ##    Input from RobotFramework> MM-DD-YYYY
-    ##    Input from Manual test > DD-MM-YYYY
-    ##    Output in cart > YYYY-MM-DD            --TT
-    Input Text    ${safari_date_input_field}    ${next_monday_date}
-    Select From List By Index    ${safari_type_dropdown}    1
-    Click Element    ${add_safari_to_cart_button}
-    Handle Alert
-
-They add a tour booked for ${chosen_day} by navigating the calendar dropdown using the keyboard to the cart  #working name -DK
+They add a tour booked for next ${chosen_day} by navigating the calendar dropdown using the keyboard to the cart  #working name -DK
     [Tags]    When
     Click Element    ${nav_menu_safari}
     Wait Until Element Is Visible    ${safari_section}    10s
@@ -138,44 +121,47 @@ They add a tour booked for ${chosen_day} by navigating the calendar dropdown usi
     Handle Alert
 
 Selecting ${chosen_day} from dropdown calendar
-    [Tags]    Under_test
-    ${button_presses}=    variables.get_days_left_until_day(${chosen_day})    modules=variables  # DESPERATION KICKING IN
+    [Tags]    Under_review    Daniel    Tan_refactor
+    Set Test Variable    ${selected_day}    ${chosen_day}    #Sets a "file wide" variable so it can be accessed later on.
+
+    ${input_count}    get_weekday_delta_offset    ${chosen_day}    #importing library of our file allows calls to funcs. -TT
+    # DESPERATION KICKING IN - DK
     # Tried several methods while waiting for food, and what I found as I gave up was something about to go eat was
     # "import keyword" and assigning keywords to the python functions -DK
     Press Keys    ${safari_date_input_field}    SPACE
-    ...    ARROW_DOWN
-    Navigate ${get_days_left_until_day(chosen_day)} steps to the right in the calendar
-    Press Key    ${safari_date_input_field}    Enter
-
-Navigate ${amount_of_steps} steps to the right in the calendar 
-    Press Key    ${safari_date_input_field}    ARROW_DOWN
+    Navigate ${input_count} steps to the right in the calendar
+    Press Keys    None    Enter
+    
+Navigate ${amount_of_steps} steps to the right in the calendar
+    [Tags]    Under_review    Daniel    Tan_refactor
+    [Documentation]    Input solution for the dynamic calendar ui in javascript.
     FOR    ${key_press}    IN RANGE    ${amount_of_steps}
-        Press Key    ${safari_date_input_field}    ARROW_RIGHT
+        Press Keys    None    ARROW_RIGHT    #i got trolled by documentation. i assumed none was literally no text -TT
+        #Sleep    0.1s    #Use this if you want to see the actual movement during calendar selection. -TT
     END
 
 They should be able to see the tour in the cart
     [Tags]    Then
     Click Element    ${nav_menu_cart}
     Wait Until Element Is Visible    ${cart_section}    10s
-    ${locale}    Execute Javascript    return navigator.language
+    #${locale}    Execute Javascript    return navigator.language
     #Log To Console    Browser locale is: ${locale}
-    #TODO: Currently expected date string is going by YY-MM-DD. Actual string is DD-MM-YY
     ${listed_items}    Get Text    ${cart_details}
+    ${expected_date} =    get_upcoming_target_weekday_date    ${selected_day}
+
     Should Not Contain    ${listed_items}    Your cart is empty
-    Should Contain    ${listed_items}    ${expected_monday_date_in_cart}
+    Should Contain    ${listed_items}    ${expected_date}
 
 ### Checkout ###
 Proceed with the purchase at checkout
     [Tags]    When
-    #TODO: Check why buying a ticket and then choosing a tour is not working.
+    #Known Issue: Buying a ticket and then choosing a tour is not working. (blame Max) --TT
     Click Element    ${nav_menu_cart}
     Wait Until Element Is Visible    ${cart_section}    10s
     Click Button    ${checkout_button}
 
 They should be able to see a checkout summary with their purchased items
     [Tags]    Then
-    # TODO Check the text maybe? Should not be needed as the checkout button only works when there's items in the cart.
-    ## test passes so i think this works??? -TT
     ${message} =    Handle Alert    #We handle + save the string attached in the alert here.
     Should Contain    ${message}    Checkout Summary:
 
@@ -195,6 +181,25 @@ They enter invalid login credentials
 
 They enter valid login credentials
     [Tags]    Internal
-    Input Text    ${LOGIN_USERNAME_FIELD}    ${USERNAME}
-    Input Text    ${LOGIN_PASSWORD_FIELD}    ${PASSWORD}
+    Input Text    ${LOGIN_USERNAME_FIELD}    ${valid_username}
+    Input Text    ${LOGIN_PASSWORD_FIELD}    ${valid_password}
     Click Element    ${submit_login}
+
+
+### Old-Code that's not in use but good for teaching/learning purposes ###
+#They add a viable tour with a chosen date to the cart
+#    [Tags]    When    Tan
+#    [Documentation]    Old solution for date input. no longer in use due to input bug within the website.
+#    Click Element    ${nav_menu_safari}
+#    Wait Until Element Is Visible    ${safari_section}    10s
+#    Click Element    ${safari_date_input_field}
+#    #old-tod-o: FIGURE OUT WHY AMERICAN DATE INPUT WORKS DESPITE OUR WEBSITE BEING DD-MM-YYYY. I hate this -TT
+#    ## I initially thought it was because we used 'en-us' locale. BUT the issue still persists with 'en-GB'.
+#    ## Conclusion: The website is trolling us. Legit decide and dont use all 3 variants man 🙃
+#    ##    Input from RobotFramework> MM-DD-YYYY
+#    ##    Input from Manual test > DD-MM-YYYY
+#    ##    Output in cart > YYYY-MM-DD            --TT
+#    Input Text    ${safari_date_input_field}    ${next_monday_date}
+#    Select From List By Index    ${safari_type_dropdown}    1
+#    Click Element    ${add_safari_to_cart_button}
+#    Handle Alert

--- a/Generic-Test-Cases/generic-keywords.robot
+++ b/Generic-Test-Cases/generic-keywords.robot
@@ -129,6 +129,30 @@ They add a viable tour with a chosen date to the cart
     Click Element    ${add_safari_to_cart_button}
     Handle Alert
 
+They add a tour booked for ${chosen_day} by navigating the calendar dropdown using the keyboard to the cart  #working name -DK
+    [Tags]    When
+    Click Element    ${nav_menu_safari}
+    Wait Until Element Is Visible    ${safari_section}    10s
+    Selecting ${chosen_day} from dropdown calendar
+    Click Element    ${add_safari_to_cart_button}
+    Handle Alert
+
+Selecting ${chosen_day} from dropdown calendar
+    [Tags]    Under_test
+    ${button_presses}=    variables.get_days_left_until_day(${chosen_day})    modules=variables  # DESPERATION KICKING IN
+    # Tried several methods while waiting for food, and what I found as I gave up was something about to go eat was
+    # "import keyword" and assigning keywords to the python functions -DK
+    Press Keys    ${safari_date_input_field}    SPACE
+    ...    ARROW_DOWN
+    Navigate ${get_days_left_until_day(chosen_day)} steps to the right in the calendar
+    Press Key    ${safari_date_input_field}    Enter
+
+Navigate ${amount_of_steps} steps to the right in the calendar 
+    Press Key    ${safari_date_input_field}    ARROW_DOWN
+    FOR    ${key_press}    IN RANGE    ${amount_of_steps}
+        Press Key    ${safari_date_input_field}    ARROW_RIGHT
+    END
+
 They should be able to see the tour in the cart
     [Tags]    Then
     Click Element    ${nav_menu_cart}

--- a/Generic-Test-Cases/generic.robot
+++ b/Generic-Test-Cases/generic.robot
@@ -37,21 +37,21 @@ User logs out successfully
     Then They should be redirected to the homepage and see the login button
 
 # Adding a tour/ticket to the cart both tests the carts functions so a dedicated test might not be needed
+# Andreas made a test for cart specifically initially, but is now null due to the other cart tests.
 User adds a ticket to the cart
-    # TODO: Check if this test needs to be reworked.
-    # The previous iteration of this only added items to the cart, it never purchased it. Should we add that?
     [Tags]    Daniel    Tan_Refactor
     [Documentation]    Assures that the user is able to purchase a ticket when they are logged in.
     Given The User Is Logged In
-    When They add a 'REGULAR' ticket to the cart    # NORMAL/VIP for ticket type choices
+    #TODO: make the regular check more dynamic (similar to date check in tour.)
+    When They add a 'REGULAR' ticket to the cart    # REGULAR/VIP for ticket type choices
     Then They should be able to see the ticket in the cart
 
 User adds a tour to the cart
     [Tags]    Andreas    Tan_refactor
     [Documentation]    Assures that the user is able to purchase a tour when they are logged in.
     Given The User Is Logged In
-    And They Add A 'REGULAR' Ticket To The Cart
-    When They add a viable tour with a chosen date to the cart
+    And They Add A 'VIP' Ticket To The Cart
+    When They add a tour booked for next SuNday by navigating the calendar dropdown using the keyboard to the cart
     Then They should be able to see the tour in the cart
 
 User adds a tour using keyboard to the cart
@@ -59,7 +59,7 @@ User adds a tour using keyboard to the cart
     [Documentation]    Assures that the user is able to purchase a tour when they are logged in.
     Given The User Is Logged In
     And They Add A 'REGULAR' Ticket To The Cart
-    When They add a tour booked for monday by navigating the calendar dropdown using the keyboard to the cart
+    When They add a tour booked for next tuesday by navigating the calendar dropdown using the keyboard to the cart
     Then They should be able to see the tour in the cart
 
 User completes a purchase

--- a/Generic-Test-Cases/generic.robot
+++ b/Generic-Test-Cases/generic.robot
@@ -54,6 +54,14 @@ User adds a tour to the cart
     When They add a viable tour with a chosen date to the cart
     Then They should be able to see the tour in the cart
 
+User adds a tour using keyboard to the cart
+    [Tags]    Andreas    Tan_refactor
+    [Documentation]    Assures that the user is able to purchase a tour when they are logged in.
+    Given The User Is Logged In
+    And They Add A 'REGULAR' Ticket To The Cart
+    When They add a tour booked for monday by navigating the calendar dropdown using the keyboard to the cart
+    Then They should be able to see the tour in the cart
+
 User completes a purchase
     [Tags]    Tan    Andreas_refactor
     [Documentation]    Asserts that the user is capable of going through with a purchase at checkout.

--- a/Generic-Test-Cases/variables.py
+++ b/Generic-Test-Cases/variables.py
@@ -8,6 +8,29 @@ url = f"file:///{current_directory}/resources/website/jurap.html"
 # endregion
 
 # region Functions
+def get_amount_of_days_until_index_of_day(index_of_day):
+    current_date = datetime.date.today()
+    return (7 + index_of_day) - current_date
+
+def get_days_left_until_day(day_of_week):
+    lower_case_day = day_of_week.lower()
+    match lower_case_day:
+        case "monday":
+            return get_amount_of_days_until_index_of_day(0)
+        case "tuesday":
+            return get_amount_of_days_until_index_of_day(1)
+        case "wednesday":
+            return get_amount_of_days_until_index_of_day(2)
+        case "thursday":
+            return get_amount_of_days_until_index_of_day(3)
+        case "friday":
+            return get_amount_of_days_until_index_of_day(4)
+        case "saturday":
+            return get_amount_of_days_until_index_of_day(5)
+        case "sunday":
+            return get_amount_of_days_until_index_of_day(6)
+
+
 def get_next_upcoming_weekday(target_weekday, date_format="YYYY-MM-DD"):
     #https://www.geeksforgeeks.org/python-program-to-get-the-nth-weekday-after-a-given-date/
     #0-6 for the days of the week, 0=monday -> 6=sunday
@@ -17,7 +40,6 @@ def get_next_upcoming_weekday(target_weekday, date_format="YYYY-MM-DD"):
         days_delta += 7
 
     date_of_next_weekday = current_date + datetime.timedelta(days_delta)
-
     # reasoning behind MM-DD-YY is due to the websites interpretation of input. it being en-us
     # reformating the date from YY-MM-DD --> to MM-DD-YY
     # https://docs.python.org/3.13/library/datetime.html#format-codes

--- a/Generic-Test-Cases/variables.py
+++ b/Generic-Test-Cases/variables.py
@@ -7,57 +7,13 @@ browser = "chrome"
 url = f"file:///{current_directory}/resources/website/jurap.html"
 # endregion
 
-# region Functions
-def get_amount_of_days_until_index_of_day(index_of_day):
-    current_date = datetime.date.today()
-    return (7 + index_of_day) - current_date
-
-def get_days_left_until_day(day_of_week):
-    lower_case_day = day_of_week.lower()
-    match lower_case_day:
-        case "monday":
-            return get_amount_of_days_until_index_of_day(0)
-        case "tuesday":
-            return get_amount_of_days_until_index_of_day(1)
-        case "wednesday":
-            return get_amount_of_days_until_index_of_day(2)
-        case "thursday":
-            return get_amount_of_days_until_index_of_day(3)
-        case "friday":
-            return get_amount_of_days_until_index_of_day(4)
-        case "saturday":
-            return get_amount_of_days_until_index_of_day(5)
-        case "sunday":
-            return get_amount_of_days_until_index_of_day(6)
-
-
-def get_next_upcoming_weekday(target_weekday, date_format="YYYY-MM-DD"):
-    #https://www.geeksforgeeks.org/python-program-to-get-the-nth-weekday-after-a-given-date/
-    #0-6 for the days of the week, 0=monday -> 6=sunday
-    current_date = datetime.date.today()
-    days_delta = target_weekday - current_date.weekday()
-    if days_delta <= 0:
-        days_delta += 7
-
-    date_of_next_weekday = current_date + datetime.timedelta(days_delta)
-    # reasoning behind MM-DD-YY is due to the websites interpretation of input. it being en-us
-    # reformating the date from YY-MM-DD --> to MM-DD-YY
-    # https://docs.python.org/3.13/library/datetime.html#format-codes
-    if date_format == "MM-DD-YYYY":
-        return date_of_next_weekday.strftime("%m-%d-%Y")
-    elif date_format == "YYYY-MM-DD":
-        return date_of_next_weekday.strftime("%Y-%m-%d")
-    else:
-        raise ValueError("Invalid date_format. Use 'DD-MM-YYYY' or 'YYYY-MM-DD'.")
+# region Home Variables
+home_section = '//*[@id="home-section"]'
 # endregion
 
-# these sections should probably be renamed to 'page'
-# random shit by Tan - will move when all tests are done. refactor my refactor yeyeyeyeye.
-home_section = '//*[@id="home-section"]'
-
 # region Credentials variables
-username = "test123"
-password = "test12345"
+valid_username = "test123"
+valid_password = "test12345"
 
 invalid_username = "123test"
 invalid_password = "12345test"
@@ -97,10 +53,9 @@ add_ticket_to_cart_button = "css:#ticket-form > button[type='submit']"
 # region Safari variables
 safari_section = '//*[@id="safari-section"]'
 
-ticket_type_dropdown = "id:ticket-category"
+ticket_category_dropdown = "id:ticket-category"
 safari_type_dropdown = "id:safari-type"
 safari_date_input_field = "xpath://input[@id='safari-date']"
-next_monday_date = get_next_upcoming_weekday(0,"MM-DD-YYYY" ) # argument is 0-6
 
 add_safari_to_cart_button = "css:#safari-form > button[type='submit']"
 # endregion
@@ -112,7 +67,6 @@ cart_details = "id:cart-details"
 item_added_to_cart_message_text = "Item added to cart!"
 
 next_monday_date_TEST = "02-28-2025" ## I DON'T GET THIS ONE, WHY IS AMERICAN INPUT FUNCTIONING HERE??? -TT
-expected_monday_date_in_cart = get_next_upcoming_weekday(0, "YYYY-MM-DD")
 # endregion
 
 # region Checkout variables

--- a/resources/global_files/weekday_helper.py
+++ b/resources/global_files/weekday_helper.py
@@ -1,0 +1,89 @@
+#https://robotframework.org/robotframework/latest/RobotFrameworkUserGuide.html#toc-entry-314
+#Creating a whole new py file to act as a helper file for specific calculations
+#Think of it as "utility" files in java -TT
+import datetime
+
+
+def get_weekday_delta_offset(day_of_week):
+    ### Accepts a string of a weekday and returns the amount of days(delta) until we that weekday: 1-7
+    # create a list, to then filter through and look for a match
+    # this will most likely look more clean compared to a match-case
+
+    weekdays = {
+        "monday": 0,
+        "tuesday": 1,
+        "wednesday": 2,
+        "thursday": 3,
+        "friday": 4,
+        "saturday": 5,
+        "sunday": 6
+    }
+
+    day_index = weekdays.get(day_of_week.lower())
+    if day_index is None:
+        # Intellisense magic. But it's essentially an error handler -TT
+        raise   ValueError(f"Invalid day of the week: {day_of_week}")
+
+    current_date = datetime.date.today()
+    delta = (day_index - current_date.weekday()) % 7
+
+    #This ensures if you are on the current weekday -
+    #you are looking for current weekday then it will jump exactly 1 week ahead -TT
+    if delta <= 0:
+        delta += 7
+
+    return delta
+
+def get_upcoming_target_weekday_date(target_weekday):
+    #https://www.geeksforgeeks.org/python-program-to-get-the-nth-weekday-after-a-given-date/
+    #0-6 for the days of the week, 0=monday -> 6=sunday
+    delta = get_weekday_delta_offset(target_weekday)
+    current_date = datetime.date.today()
+
+    date_of_next_weekday = current_date + datetime.timedelta(delta)
+    return date_of_next_weekday.strftime("%Y-%m-%d")
+
+# region old-functions
+# def get_amount_of_days_until_index_of_day(index_of_day):
+#     current_date = datetime.date.today()
+#     return (index_of_day - current_date.weekday()) % 7
+#
+# def get_days_left_until_day(day_of_week):
+#     lower_case_day = day_of_week.lower()
+#     match lower_case_day:
+#         case "monday":
+#             return get_amount_of_days_until_index_of_day(0)
+#         case "tuesday":
+#             return get_amount_of_days_until_index_of_day(1)
+#         case "wednesday":
+#             return get_amount_of_days_until_index_of_day(2)
+#         case "thursday":
+#             return get_amount_of_days_until_index_of_day(3)
+#         case "friday":
+#             return get_amount_of_days_until_index_of_day(4)
+#         case "saturday":
+#             return get_amount_of_days_until_index_of_day(5)
+#         case "sunday":
+#             return get_amount_of_days_until_index_of_day(6)
+#
+#
+# def get_next_upcoming_weekday(target_weekday, date_format="YYYY-MM-DD"):
+#     #https://www.geeksforgeeks.org/python-program-to-get-the-nth-weekday-after-a-given-date/
+#     #0-6 for the days of the week, 0=monday -> 6=sunday
+#     current_date = datetime.date.today()
+#
+#     days_delta = (target_weekday - current_date.weekday()) % 7
+#     if days_delta <= 0:
+#         days_delta += 7
+#
+#     date_of_next_weekday = current_date + datetime.timedelta(days_delta)
+#     # reasoning behind MM-DD-YY is due to the websites interpretation of input. it being en-us
+#     # reformating the date from YY-MM-DD --> to MM-DD-YY
+#     # https://docs.python.org/3.13/library/datetime.html#format-codes
+#     if date_format == "MM-DD-YYYY":
+#         return date_of_next_weekday.strftime("%m-%d-%Y")
+#     elif date_format == "YYYY-MM-DD":
+#         return date_of_next_weekday.strftime("%Y-%m-%d")
+#     else:
+#         raise ValueError("Invalid date_format. Use 'DD-MM-YYYY' or 'YYYY-MM-DD'.")
+# endregion


### PR DESCRIPTION
Redid the entire calendar picking method into keyinputs.
This avoids the current issue of dateinput caused by localhosting the website #Blame-Max